### PR TITLE
Emit 'error' event if no job servers are available

### DIFF
--- a/lib/gearmanode/client.js
+++ b/lib/gearmanode/client.js
@@ -160,7 +160,9 @@ Client.prototype.submitJob = function(name, payload, options) {
 
     tryToSend = function() {
         jobServer = self._getJobServer();
-        if (!jobServer) { return; } // problem already escalated by '_getJobServer'; there are no other servers -> return
+        if (!jobServer) {
+        	return job.emit('error', new Error('All job servers fail'));
+        } // problem already escalated by '_getJobServer'; there are no other servers -> return
 
         jobServer.send(packet, jsSendCallback);
     }


### PR DESCRIPTION
If all servers fail, an event should be emitted on job object.