### PR TITLE
Fix the error of 'out of sync'

### DIFF
--- a/lib/gearmanode/job-server.js
+++ b/lib/gearmanode/job-server.js
@@ -300,13 +300,22 @@ JobServer.prototype._processData = function (chunk) {
         return;
     }
 
+    if (chunk.length<protocol.CONSTANTS.HEADER_LEN) {//header is not enough
+        this.headerfrag = nextChunk;
+        return;
+    }
+
     if (chunk.readUInt32BE(0) !== protocol.CONSTANTS.HEADER_RESP) {
-        if (!this.hasOwnProperty('segmentedPacket')) { // not previous packet stored to be concatenated -> it must be error
+        if (this.hasOwnProperty('segmentedPacket')) {
+            chunk = Buffer.concat([this.segmentedPacket, chunk]);            
+        } else if (this.hasOwnProperty('headerfrag')) {
+            chunk = Buffer.concat([this.headerfrag, chunk]);
+            delete this.headerfrag;
+        } else{ // not previous packet stored to be concatenated -> it must be error
             // OUT OF SYNC!
             this.clientOrWorker._unrecoverableError('out of sync with server');
             return;
         }
-        chunk = Buffer.concat([this.segmentedPacket, chunk]);
     }
 
     var packetType = chunk.readUInt32BE(4);
@@ -327,11 +336,16 @@ JobServer.prototype._processData = function (chunk) {
         if (JobServer.logger.isLevelEnabled('verbose')) {
             JobServer.logger.log('verbose', 'joined packet found, responseSize=%d, packetLen=%d', responseLength, chunk.length);
         }
-        nextChunk = chunk.slice(responseLength, chunk.length);
-        var self = this;
-        process.nextTick(function() {
-            self._processData(nextChunk);
-        });
+        nextChunk = new Buffer(chunk.slice(responseLength));
+        if (nextChunk.length>=protocol.CONSTANTS.HEADER_LEN) {//header complete
+            var self = this;
+            process.nextTick(function() {
+                self._processData(nextChunk);
+            });
+        } else{//header is not enough
+            this.headerfrag = nextChunk;
+        }
+
         chunk = chunk.slice(0, responseLength);
     }
 


### PR DESCRIPTION
when the data is less than 12(header length), it causes the error of 'out of sync'.So,the data the length of which is less than 12 shoule be stored and concated with the next packet that don't have the header.