### PR TITLE
Feature/error on no server

### DIFF
--- a/lib/gearmanode/client.js
+++ b/lib/gearmanode/client.js
@@ -168,7 +168,8 @@ Client.prototype.submitJob = function(name, payload, options) {
         jobServer.send(packet, jsSendCallback);
     }
 
-    tryToSend();
+    // Allow to add an handler to the job on 'error' event
+    process.nextTick(tryToSend);
     return job;
 }
 

--- a/lib/gearmanode/job-server.js
+++ b/lib/gearmanode/job-server.js
@@ -110,6 +110,7 @@ JobServer.prototype.connect = function (callback) {
         // emitted when an error occurs
         this.socket.on('error', function (err) {
             JobServer.logger.log('error', 'socket error:', err);
+            var connected = self.connected;
             // ensures that no more I/O activity happens on this socket
             self.socket.destroy();
 
@@ -122,7 +123,9 @@ JobServer.prototype.connect = function (callback) {
             self.clientOrWorker.emit('socketError', self.getUid(), err); // trigger event
             self.disconnect(err);
 
-            callback(err);
+            if (!connected) {
+              callback(err);
+            }
         });
 
         this.socket.on('data', function (chunk) {


### PR DESCRIPTION
If "_getJobServer" method doesn't return a valid JobServer, an error is emitted.
The event could be fired before any 'error' event listeners are attached.
This could crash the process.

Using nextTick, the developer is able to add an 'error' handler.

On connect method, the callback should be called only one time. The security guard is a good thing